### PR TITLE
Dev

### DIFF
--- a/UploadForm.py
+++ b/UploadForm.py
@@ -4,19 +4,22 @@ from urllib.parse import urljoin,urlparse
 from threading import Lock
 
 class UploadForm :
-	def __init__(self,notRegex,trueRegex,session,size,postData,uploadsFolder=None) :
+	def __init__(self,notRegex,trueRegex,session,size,postData,uploadsFolder=None,formUrl=None,formAction=None,inputName=None) :
 		self.logger = logging.getLogger("fuxploider")
 		self.postData = postData
-		#self.uploadUrl = uploadUrl
-		#self.formUrl = formUrl
+		self.formUrl = formUrl
+		url = urlparse(self.formUrl)
+		self.schema = url.scheme
+		self.host = url.netloc
+		self.uploadUrl = urljoin(formUrl, formAction)
 		self.session = session
 		self.trueRegex = trueRegex
 		self.notRegex = notRegex
-		#self.inputName = inputName
+		self.inputName = inputName
 		self.uploadsFolder = uploadsFolder
 		self.size = size
 		self.validExtensions = []
-		#self.httpRequests = 0
+		self.httpRequests = 0
 		self.codeExecUrlPattern = None #pattern for code exec detection using true regex findings
 		self.logLock = Lock()
 		self.stopThreads = False

--- a/UploadForm.py
+++ b/UploadForm.py
@@ -231,10 +231,12 @@ class UploadForm :
 					executedCode = self.detectCodeExec(url,codeExecRegex)
 					if executedCode :
 						result["codeExec"] = True
+						result["url"] = url
 				if secondUrl :
 					executedCode = self.detectCodeExec(secondUrl,codeExecRegex)
 					if executedCode :
 						result["codeExec"] = True
+						result["url"] = secondUrl
 		return result
 
 	#detects html forms and returns a list of beautifulSoup objects (detected forms)

--- a/fuxploider.py
+++ b/fuxploider.py
@@ -293,7 +293,7 @@ with concurrent.futures.ThreadPoolExecutor(max_workers=args.nbThreads) as execut
 				if res["codeExec"] :
 
 					foundEntryPoint = future.a
-					logging.info("\033[1m\033[42mCode execution obtained ('%s','%s','%s')\033[m",foundEntryPoint["suffix"],foundEntryPoint["mime"],foundEntryPoint["templateName"])
+					logging.info("\033[1m\033[42mCode execution obtained ('%s','%s','%s','%s')\033[m",foundEntryPoint["suffix"],foundEntryPoint["mime"],foundEntryPoint["templateName"],res["url"])
 					nbOfEntryPointsFound += 1
 					entryPoints.append(foundEntryPoint)
 

--- a/fuxploider.py
+++ b/fuxploider.py
@@ -53,6 +53,11 @@ exclusiveUserAgentsArgs = parser.add_mutually_exclusive_group()
 exclusiveUserAgentsArgs.add_argument("-U","--user-agent",metavar="useragent",nargs=1,dest="userAgent",help="User-agent to use while requesting the target.",type=str,default=[requests.utils.default_user_agent()])
 exclusiveUserAgentsArgs.add_argument("--random-user-agent",action="store_true",required=False,dest="randomUserAgent",help="Use a random user-agent while requesting the target.")
 
+manualFormArgs = parser.add_argument_group('Manual Form Detection arguments')
+manualFormArgs.add_argument("-m","--manual-form-detection",action="store_true",dest="manualFormDetection",help="Disable automatic form detection. Useful when automatic detection fails due to: (1) Form loaded using Javascript (2) Multiple file upload forms in URL.")
+manualFormArgs.add_argument("--input-name",metavar="image",dest="inputName",help="Name of input for file. Example: <input type=\"file\" name=\"image\">")
+manualFormArgs.add_argument("--form-action",default="",metavar="upload.php",dest="formAction",help="Path of form action. Example: <form method=\"POST\" action=\"upload.php\">")
+
 args = parser.parse_args()
 args.uploadsPath = args.uploadsPath[0]
 args.nbThreads = args.nbThreads[0]
@@ -111,6 +116,9 @@ if args.legitExtensions :
 
 if args.cookies :
 	args.cookies = postDataFromStringToJSON(args.cookies[0])
+
+if args.manualFormDetection and args.inputName is None:
+	parser.error("--manual-form-detection requires --input-name")
 
 print("""\033[1;32m
                                      
@@ -189,8 +197,13 @@ if args.proxy :
 	s.proxies.update(proxies)
 #########################################################
 
-up = UploadForm(args.notRegex,args.trueRegex,s,args.size,postData,args.uploadsPath)
-up.setup(args.url)
+if args.manualFormDetection:
+	if args.formAction == "":
+		logger.warning("Using Manual Form Detection and no action specified with --form-action. Defaulting to empty string - meaning form action will be set to --url parameter.")
+	up = UploadForm(args.notRegex,args.trueRegex,s,args.size,postData,args.uploadsPath,args.url,args.formAction,args.inputName)
+else:
+	up = UploadForm(args.notRegex,args.trueRegex,s,args.size,postData,args.uploadsPath)
+	up.setup(args.url)
 up.threads = args.nbThreads
 #########################################################
 


### PR DESCRIPTION
Added 2 new features:

1. URL of payload displayed when achieved code execution - for manual verification with browser

2. "Manual Form Detection" mode for manually entering form parameters

In some cases, the automatic form detection fails, for example:
- HTML form is loaded dynamically via JavaScript
- Multiple HTML forms exist with file upload functionality
- Multiple file inputs exist in the same form

In these cases, it is now possible to use "Manual Form Detection" mode
which allows to manually set the name of the file input tag and the
form action (target path of form).