### PR TITLE
Equal signs in post data fix

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -62,7 +62,7 @@ def postDataFromStringToJSON(params) :
 		prePostData = params.split("&")
 		postData = {}
 		for d in prePostData :
-			p = d.split("=")
+			p = d.split("=", 1)
 			postData[p[0]] = p[1]
 		return postData
 	else :


### PR DESCRIPTION
There is a problem if the post data contains the equal sign "=" (for example base64-encoded data et.c.).
The p = d.split("=") splits on all occurences of "=". I changed it to p = d.split("=", 1) to split only on the first occurence (which is what we really want).