### PR TITLE
Bump Dockerfile base image to python:3.6-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-alpine
+FROM python:3.6-alpine
 LABEL author="Mostafa Hussein <mostafa.hussein91@gmail.com>"
 RUN apk add --no-cache gcc musl-dev libxml2-dev libxslt-dev openssl
 COPY . /home/fuxploider


### PR DESCRIPTION
* Fix #16: fuxploider uses f-strings, which were introduced in python 3.6. This
change will update the Dockerfile to use a supported python version.
