### PR TITLE
SSL InsecureRequestWarning issue resolved.

### DIFF
--- a/fuxploider.py
+++ b/fuxploider.py
@@ -16,6 +16,9 @@ from utils import *
 from UploadForm import UploadForm
 from threading import Lock
 
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
 __version__ = "1.0.0"
 logging.basicConfig(datefmt='[%m/%d/%Y-%H:%M:%S]')
 logger = logging.getLogger("fuxploider")


### PR DESCRIPTION
From [issue#35](https://github.com/almandin/fuxploider/issues/35), we can see that users are getting SSL errors. I added two lines of codes to resolve it.
```
from requests.packages.urllib3.exceptions import InsecureRequestWarning
requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
```