### PR TITLE
Fix Manual Form Detection with True-Regex

### DIFF
--- a/UploadForm.py
+++ b/UploadForm.py
@@ -141,7 +141,11 @@ class UploadForm:
                 if self.trueRegex:
                     moreInfo = re.search(self.trueRegex, html)
                     if moreInfo:
-                        result = str(moreInfo.groups())
+                        try:
+                            result = str(moreInfo.group(1))
+                        except:
+                            result = str(moreInfo.group(0))
+                            
         if self.trueRegex and not result:
             fileUploaded = re.search(self.trueRegex, html)
             if fileUploaded:

--- a/fuxploider.py
+++ b/fuxploider.py
@@ -156,8 +156,8 @@ if args.manualFormDetection and args.inputName is None:
 
 print("""\033[1;32m
 
- ___             _     _   _ 
-|  _|_ _ _ _ ___| |___|_|_| |___ ___ 
+ ___             _     _   _
+|  _|_ _ _ _ ___| |___|_|_| |___ ___
 |  _| | |_'_| . | | . | | . | -_|  _|
 |_| |___|_,_|  _|_|___|_|___|___|_|
             |_|
@@ -244,6 +244,15 @@ if args.manualFormDetection:
                        "Defaulting to empty string - meaning form action will be set to --url parameter.")
     up = UploadForm(args.notRegex, args.trueRegex, s, args.size, postData, args.uploadsPath,
                     args.url, args.formAction, args.inputName)
+    if not args.uploadsPath and args.trueRegex:
+        print("No uploads path provided, code detection can still be done "
+              "using true regex capturing group. "
+              "(Except for templates with a custom codeExecURL)")
+        cont = input("Do you want to use the True Regex for code execution detection ? [Y/n] ")
+        if cont.lower().startswith("y") or cont == "":
+            prefixPattern = input("Prefix capturing group of the true regex with: ")
+            suffixPattern = input("Suffix capturing group of the true regex with: ")
+            up.codeExecUrlPattern = "".join((prefixPattern, "$captGroup$", suffixPattern))
 else:
     up = UploadForm(args.notRegex, args.trueRegex, s, args.size, postData, args.uploadsPath)
     up.setup(args.url)
@@ -404,3 +413,4 @@ d = datetime.datetime.now()
 logging.info("%s entry point(s) found using %s HTTP requests.", nbOfEntryPointsFound, up.httpRequests)
 print("\nFound the following entry points: ")
 print(entryPoints)
+


### PR DESCRIPTION
# Issue #1 - Fix Manual Form Detection with True-Regex
When using manual form detection (`-m` flag) with the `--true-regex` parameter but without `--uploads-path`, the code never prompts the user to enter prefix/suffix values for the regex match. This prevents the tool from correctly constructing URLs to test for code execution.

The problem occurs because the prompting code is only in the `setup()` method of the `UploadForm` class, which is bypassed when using manual form detection.

## Fix
This PR adds the missing prompting code to the manual form detection path, ensuring users can specify prefix/suffix values regardless of which detection method they use.

## How to Test
Run Fuxploider with a command using manual form (`-m` flag) detection and the `--true-regex` parameter but without `--uploads-path`:

```
python fuxploider.py -u "https://example.com" -m --input-name "files[]" --form-action "upload?output=json" --true-regex 'filename": "([^"]+)"' --not-regex '"success":\s*false,'
```

You should now be prompted with:
```
No uploads path provided, code detection can still be done using true regex capturing group.
Do you want to use the True Regex for code execution detection ? [Y/n]
```

And after answering 'Y':
```
Prefix capturing group of the true regex with:
Suffix capturing group of the true regex with:
```
# Issue 2 - Fix Regex Capture Handling Inconsistency

When using both `--true-regex` and `--not-regex` parameters together, Fuxploider handles the regex captures inconsistently, resulting in malformed URLs during code execution testing.

Specifically:
- With `--not-regex` and `--true-regex` together: Capture results are returned as a string representation of a tuple (`('filename.ext',)`), creating invalid URLs like `https://example.com/('file.php',)`
- With only `--true-regex`: Capture results are correctly returned as a simple string (`filename.ext`), creating valid URLs like `https://example.com/file.php`

This inconsistency exists because of two different code paths in the `isASuccessfulUpload` method in `UploadForm.py`:
1. When using both parameters: `result = str(moreInfo.groups())`
2. When using only true-regex: `result = str(fileUploaded.group(1))`

## Fix
This PR standardizes how regex captures are handled by modifying the first code path to use the same approach as the second. It replaces:

```python
result = str(moreInfo.groups())
```

With:

```python
try:
    result = str(moreInfo.group(1))
except:
    # Fallback to group(0) if no capture groups
    result = str(moreInfo.group(0))
```

This ensures consistent behavior regardless of which combination of regex parameters is used.

## How to Test
Run Fuxploider with both parameters:

```
python fuxploider.py -u "https://example.com" -m -y --input-name "files[]" --form-action "upload?output=json" --true-regex 'filename": "([^"]+)"' --not-regex '"success":\s*false,'
```

Before the fix, URLs in debug output would look like:
```
Requesting https://example.com/('filename.ext',) ...
```

After the fix, URLs should look like:
```
Requesting https://example.com/filename.ext ...
```
